### PR TITLE
feat(ci): add a typescript lint stage

### DIFF
--- a/.github/workflows/pipelinit.lint-typescript.yaml
+++ b/.github/workflows/pipelinit.lint-typescript.yaml
@@ -1,0 +1,14 @@
+
+name: Lint Typescript
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Node
+      uses: actions/setup-node@v2
+      with:
+        cache: 'yarn'
+    - run: yarn
+    - run: find ./ -name ".eslintrc.*" | grep -v "node_modules" && ./node_modules/eslint/bin/eslint.js --ext .ts . || eslint --no-eslintrc --ext .ts .


### PR DESCRIPTION
Uses the pipelinit tool to generate a lint pipeline on the code
By default, it should use the configuration added on the PR https://github.com/operous/test-ssh-action/pull/4

To test:
- The workflow is active in all branches on push, just verify the executed actions on your project after you made a push
![image](https://user-images.githubusercontent.com/30262244/128018255-1b2d001a-373e-49d1-bff1-58603a24a6fb.png)
![image](https://user-images.githubusercontent.com/30262244/128018291-3f1db6b3-3901-4125-aa05-8ff609c18afb.png)
![image](https://user-images.githubusercontent.com/30262244/128018382-ad655e83-f7eb-45f6-b429-e14929441016.png)
